### PR TITLE
Use uuid in fetchq.metrics_writes

### DIFF
--- a/Dockerfile-13.2
+++ b/Dockerfile-13.2
@@ -1,0 +1,3 @@
+FROM postgres:13.2
+ADD ./extension /usr/share/postgresql/13/extension/
+ADD ./docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ build:
 		$(CURDIR)/src/queue-truncate.sql \
 		$(CURDIR)/src/utils-ts-retain.sql \
 		$(CURDIR)/src/trace.sql \
+		$(CURDIR)/src/upgrade_3.1.0_3.1.1.sql \
 		> $(CURDIR)/extension/fetchq--${version}.sql
 
 build-test:

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,31 @@
 
 registry ?= fetchq
 name ?= fetchq
-version ?= 3.1.0
+version ?= 3.1.1
 
 ## Testing with Postgres Versions
 ## It's a good idea to always test with all the versions
 ## it's manual and it sucks, we'll see about that in the future
 
-# 9.6 10.11 11.6 12.1 12.4 13.0
-pg_version ?= 13.0
-# 9.6 10 11.6 12 13
+# pg_version ?= 9.6
+# pg_extension_folder ?= 9.6
+
+# pg_version ?= 10.4
+# pg_extension_folder ?= 10
+
+# pg_version ?= 10.11
+# pg_extension_folder ?= 10
+
+# pg_version ?= 12.1
+# pg_extension_folder ?= 12
+
+# pg_version ?= 12.4
+# pg_extension_folder ?= 12
+
+# pg_version ?= 13.0
+# pg_extension_folder ?= 13
+
+pg_version ?= 13.2
 pg_extension_folder ?= 13
 
 reset:
@@ -148,6 +164,7 @@ build-image: reset build
 	docker build --no-cache -t ${name}:12.1-${version} -f Dockerfile-12.1 .
 	docker build --no-cache -t ${name}:12.4-${version} -f Dockerfile-12.4 .
 	docker build --no-cache -t ${name}:13.0-${version} -f Dockerfile-13.0 .
+	docker build --no-cache -t ${name}:13.2-${version} -f Dockerfile-13.2 .
 
 publish: build-image
 	# 9.6
@@ -190,6 +207,11 @@ publish: build-image
 	docker tag ${name}:13.0-${version} ${registry}/${name}:13.0-latest
 	docker push ${registry}/${name}:13.0-${version}
 	docker push ${registry}/${name}:13.0-latest
+	# 13.2
+	docker tag ${name}:13.2-${version} ${registry}/${name}:13.2-${version}
+	docker tag ${name}:13.2-${version} ${registry}/${name}:13.2-latest
+	docker push ${registry}/${name}:13.2-${version}
+	docker push ${registry}/${name}:13.2-latest
 	# latest
 	docker tag ${name}:13.0-${version} ${registry}/${name}:latest
 	docker push ${registry}/${name}:latest

--- a/src/fetchq.control
+++ b/src/fetchq.control
@@ -1,4 +1,4 @@
 # FetchQ Node Extension
 comment = 'fetchq node'
-default_version = '3.1.0'
+default_version = '3.1.1'
 relocatable = true

--- a/src/info.sql
+++ b/src/info.sql
@@ -8,6 +8,6 @@ CREATE OR REPLACE FUNCTION fetchq.info(
     OUT version VARCHAR
 ) AS $$
 BEGIN
-	version='3.1.0';
+	version='3.1.1';
 END; $$
 LANGUAGE plpgsql;

--- a/src/init.sql
+++ b/src/init.sql
@@ -40,7 +40,7 @@ BEGIN
 
     -- Metrics Writes
     CREATE TABLE IF NOT EXISTS fetchq.metrics_writes(
-        id SERIAL PRIMARY KEY,
+        id VARCHAR(36) DEFAULT uuid_generate_v1(),
         created_at TIMESTAMP WITH TIME ZONE,
         queue CHARACTER VARYING(40) NOT NULL,
         metric CHARACTER VARYING(40) NOT NULL,

--- a/src/init.sql
+++ b/src/init.sql
@@ -40,7 +40,7 @@ BEGIN
 
     -- Metrics Writes
     CREATE TABLE IF NOT EXISTS fetchq.metrics_writes(
-        id VARCHAR(36) DEFAULT uuid_generate_v1(),
+        id UUID DEFAULT uuid_generate_v1(),
         created_at TIMESTAMP WITH TIME ZONE,
         queue CHARACTER VARYING(40) NOT NULL,
         metric CHARACTER VARYING(40) NOT NULL,

--- a/src/upgrade_3.1.0_3.1.1.sql
+++ b/src/upgrade_3.1.0_3.1.1.sql
@@ -1,0 +1,27 @@
+
+DROP FUNCTION IF EXISTS fetchq.upgrade__310__311();
+CREATE OR REPLACE FUNCTION fetchq.upgrade__310__311(
+    OUT success BOOLEAN
+) AS $$
+DECLARE
+    VAR_q VARCHAR;
+BEGIN
+    -- temporary cast integers to strings:
+    ALTER TABLE "fetchq"."metrics_writes" 
+    ALTER COLUMN "id" SET DATA TYPE VARCHAR(36),
+    ALTER COLUMN "id" SET DEFAULT uuid_generate_v1();
+
+    -- update the existing lines to use uuids:
+    UPDATE "fetchq"."metrics_writes" SET "id" = uuid_generate_v1();
+
+    -- cast the string type to be uuid:
+    ALTER TABLE "fetchq"."metrics_writes"
+    ALTER COLUMN "id" SET DATA TYPE UUID USING "id"::UUID,
+    ALTER COLUMN "id" SET DEFAULT uuid_generate_v1();
+
+    -- drop the integer sequence:
+    DROP SEQUENCE IF EXISTS "fetchq"."metrics_writes_id_seq" CASCADE;
+
+    success = true;
+END; $$
+LANGUAGE plpgsql;

--- a/tests/_before.sql
+++ b/tests/_before.sql
@@ -13,8 +13,6 @@ CREATE SCHEMA fetchq_data;
 DROP SCHEMA IF EXISTS fetchq_test CASCADE;
 CREATE SCHEMA fetchq_test;
 
-
-
 -- Called at the beginning of every test case
 CREATE OR REPLACE FUNCTION fetchq_test.__beforeEach(
     OUT done BOOLEAN
@@ -46,10 +44,11 @@ SET client_min_messages = error
 AS $$
 BEGIN
     -- Cleanup previous state
-    DROP SCHEMA IF EXISTS fetchq CASCADE;
-    DROP SCHEMA IF EXISTS fetchq_data CASCADE;
-    DROP EXTENSION IF EXISTS fetchq CASCADE;
-    DROP EXTENSION IF EXISTS "uuid-ossp";
+    -- No need, a new test will cleanup in the "beforeEach"
+    -- DROP SCHEMA IF EXISTS fetchq CASCADE;
+    -- DROP SCHEMA IF EXISTS fetchq_data CASCADE;
+    -- DROP EXTENSION IF EXISTS fetchq CASCADE;
+    -- DROP EXTENSION IF EXISTS "uuid-ossp";
     done = TRUE;
 END; $$
 LANGUAGE plpgsql;
@@ -112,65 +111,25 @@ DETAILS:
 
     -- Cleanup AFTER test execution
     PERFORM fetchq_test.__afterEach();
+    
     done = TRUE;
 END; $$
 LANGUAGE plpgsql;
 
 
-
-
-CREATE OR REPLACE FUNCTION fetchq_test.__runWIP(
-    PAR_testName VARCHAR,
-    PAR_testAssert VARCHAR,
-    OUT done BOOLEAN
-) AS $$
-DECLARE
-	VAR_q VARCHAR;
-    VAR_errMessage TEXT;
-    VAR_errDetails TEXT;
-    VAR_errHint TEXT;
+CREATE OR REPLACE FUNCTION fetchq_test.expect_equalInt(
+    VAR_received INTEGER,
+    VAR_expected INTEGER,
+    VAR_message TEXT,
+    OUT VAR_res BOOLEAN
+) 
+SET client_min_messages = error
+AS $$
 BEGIN
-
-    -- Cleanup BEFORE test execution
-    PERFORM fetchq_test.__beforeEach();
-
-    -- Prepare test statement
-    VAR_q = 'SELECT * FROM fetchq_test.';
-	VAR_q = VAR_q || PAR_testName;
-	VAR_q = VAR_q || '();';
-	VAR_q = FORMAT(VAR_q, PAR_testName);
-
-    -- Try/catch the test and present a nice error message
-    BEGIN
-        EXECUTE VAR_q;
-    EXCEPTION WHEN OTHERS THEN
-        GET STACKED DIAGNOSTICS VAR_errMessage = MESSAGE_TEXT,
-                                VAR_errDetails = PG_EXCEPTION_DETAIL,
-                                VAR_errHint = PG_EXCEPTION_HINT;
-        RAISE EXCEPTION E'
-
-
-
-##########################
-### FETCHQ TEST FAILED ###
-##########################
-
-TEST:
-> fetchq_test.%()
-%
-
-ERROR:
-%
-%
-
-DETAILS:
-%
-
-
-
-'
-, PAR_testName, PAR_testAssert, VAR_errMessage, VAR_errHint, VAR_errDetails;
-    END;
-    done = TRUE;
+    IF VAR_expected != VAR_received THEN 
+        RAISE EXCEPTION '% - (expected %, got %)', VAR_message, VAR_expected, VAR_received; 
+    END IF;
+    VAR_res = true;
 END; $$
 LANGUAGE plpgsql;
+

--- a/tests/_run.sql
+++ b/tests/_run.sql
@@ -1,23 +1,27 @@
 
--- CREATE OR REPLACE FUNCTION fetchq_test.__runWIP(
---     OUT done BOOLEAN
--- ) AS $$
--- DECLARE
---     VAR_errMessage TEXT;
--- BEGIN
---     BEGIN
+CREATE OR REPLACE FUNCTION fetchq_test.__runDevelopement(
+    OUT done BOOLEAN
+) AS $$
+DECLARE
+    VAR_errMessage TEXT;
+BEGIN
+    BEGIN
 
---         -- >>> Run tests
---         PERFORM fetchq_test.__runWIP('queue_triggers_01', 'It should run triggers on documents');
---         -- <<<
+        -- >>> Run tests
+        -- PERFORM fetchq_test.__runWIP('queue_triggers_01', 'It should run triggers on documents');
+        -- PERFORM fetchq_test.__run('queue_create_01', '');
+        PERFORM fetchq_test.__run('metric_log_pack_01', '');
+        PERFORM fetchq_test.__run('metric_log_pack_02', '');
+        -- PERFORM fetchq_test.__run('queue_truncate_01', 'It should truncate a queue by name');
+        -- <<<
 
---     EXCEPTION WHEN OTHERS THEN
---         GET STACKED DIAGNOSTICS VAR_errMessage = MESSAGE_TEXT;
---         RAISE EXCEPTION '%', VAR_errMessage;
---     END;
---     done = TRUE;
--- END; $$
--- LANGUAGE plpgsql;
+    EXCEPTION WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS VAR_errMessage = MESSAGE_TEXT;
+        RAISE EXCEPTION '%', VAR_errMessage;
+    END;
+    done = TRUE;
+END; $$
+LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION fetchq_test.__runBasics(
@@ -45,6 +49,7 @@ BEGIN
         PERFORM fetchq_test.__run('doc_complete_01', '');
         PERFORM fetchq_test.__run('doc_kill_01', '');
         PERFORM fetchq_test.__run('doc_drop_01', '');
+        PERFORM fetchq_test.__run('metric_log_pack_02', '');
         -- <<<
 
     EXCEPTION WHEN OTHERS THEN
@@ -134,7 +139,7 @@ LANGUAGE plpgsql;
 
 
 -- Define which groups to run
--- select * from fetchq_test.__runWIP();
+-- select * from fetchq_test.__runDevelopement();
 select * from fetchq_test.__runBasics();
 select * from fetchq_test.__runOptionals();
 


### PR DESCRIPTION
fixes #38

The relevant change is in `src/init.sql`, it's just one change that will set the system to use uuid instead of an integer series.
The other changes are either for testing or for bumping up the version.

I'm not actually sure whether this would be a bugfix, minor or major change.
Technically it doesn't break compatibility. 
